### PR TITLE
modified Sprintf string so alarm time correctly formats with leading 0

### DIFF
--- a/ui/ClockPane.go
+++ b/ui/ClockPane.go
@@ -123,7 +123,7 @@ func (p *ClockPane) Render() (*image.RGBA, error) {
 	var text string
 	if p.alarm != nil {
 		duration := p.alarm.Sub(time.Now())
-		text = fmt.Sprintf("%d:%0d", int(duration.Minutes()), int(duration.Seconds())-(int(duration.Minutes())*60))
+		text = fmt.Sprintf("%d:%02d", int(duration.Minutes()), int(duration.Seconds())-(int(duration.Minutes())*60))
 	} else {
 
 		t := time.Now()


### PR DESCRIPTION
 as, e.g. "0:09" instead of "0:9"
@elliots and/or @jonseymour 
